### PR TITLE
fix return value for single email address of Message::normalizeEmail()

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -265,6 +265,7 @@ class Message
     public function sender($email, $name = null)
     {
         $emails = $this->normalizeEmail($email);
+        $emails = is_array($email) ? $email : [$emails];
 
         foreach ($emails as $email) {
             $this->getMessage()->setSender($email, $name);
@@ -843,7 +844,7 @@ class Message
      *
      * @param string|array|\Traversable $email
      *
-     * @return array
+     * @return string|array
      */
     protected function normalizeEmail($email)
     {
@@ -862,8 +863,7 @@ class Message
 
             return $emails;
         } else {
-            $emails[] = $this->getManager()->normalizeEmail($email);
-            return $emails;
+            return $this->getManager()->normalizeEmail($email);
         }
     }
 }


### PR DESCRIPTION
In Message class, from() method with a name argument does not work properly. The same applies replyTo() method and to(), cc(), bcc().
Because, normalizeEmail() method in Message class return always array type.
In Swift Mailer Message class, the setFrom() method with a name argument needs a string email and a name argument, not array type email.
This pull request fixes its problem.

Please validate it.