### PR TITLE
Update Manager.php

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -109,7 +109,7 @@ class Manager extends Injectable implements EventsAwareInterface
 
         if (isset($config['username'])) {
             $this->mailer->Username = $config['username'];
-
+            $this->mailer->SMTPAuth = true;
             if (isset($config['password'])) {
                 $this->mailer->Password = $config['password'];
             }


### PR DESCRIPTION
As per the PHPMailer source code, it's necessary to explicitly set `$mailer->SMTPAuth = true.`  I've recently verified this while using the AWS Simple Email Service; otherwise, it leads to an SMTP error code 530 response.