### PR TITLE
fixed smtp auth

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -108,6 +108,9 @@ class Manager extends Injectable implements EventsAwareInterface
         }
 
         if (isset($config['username'])) {
+
+            $this->mailer->SMTPAuth = true;
+
             $this->mailer->Username = $config['username'];
 
             if (isset($config['password'])) {


### PR DESCRIPTION
when smtp require authentication, we should declare the smtpAuth as true, because PHPMailer declare it as false in default.

```
    /**
     * Whether to use SMTP authentication.
     * Uses the Username and Password properties.
     *
     * @see PHPMailer::$Username
     * @see PHPMailer::$Password
     *
     * @var bool
     */
    public $SMTPAuth = false;
```